### PR TITLE
Fix: Add Equality Sign to Converters

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -84,7 +84,7 @@ func (c *converters) parseVariableStringField(r string, maxLen int) (got string,
 
 	hasDelimiter := false
 	size = min(endIndex, delimiterIndex)
-	if size > maxLen {
+	if size >= maxLen {
 		size = maxLen
 	} else if size < maxLen {
 		if delimiterIndex == size {

--- a/converters_test.go
+++ b/converters_test.go
@@ -59,6 +59,11 @@ func TestConverters__parseVariableStringField(t *testing.T) {
 	require.Equal(t, "123", got)
 	require.Equal(t, 3, size)
 	require.Nil(t, err)
+
+	got, size, err = c.parseVariableStringField("123*567", 3)
+	require.Equal(t, "123", got)
+	require.Equal(t, 3, size)
+	require.Nil(t, err)
 }
 
 func TestConverters_alphaVariableField(t *testing.T) {


### PR DESCRIPTION
Adds an equal sign to account for when values are the same. The logic makes the value the same as the 'size' so this case is already covered in existing test cases.